### PR TITLE
Update nrc.html to 301 redirect to new NRC website.

### DIFF
--- a/_layouts/nrc.html
+++ b/_layouts/nrc.html
@@ -1,5 +1,5 @@
 ---
-layout: tabbed
+layout: null
 title: Northeastern Recreational Climbing
 author: Northeastern Recreational Climbing
 color: 004B4B
@@ -8,4 +8,15 @@ home: true
 data: nrc
 url: /nrc/
 ---
-{{ content }}
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <meta http-equiv="refresh" content="0; url=https://northeasternclimbing.com/">
+  <link rel="canonical" href="https://northeasternclimbing.com/" />
+</head>
+<body>
+  <p>If you are still on this page, <a href="https://northeasternclimbing.com/">please click here</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
The NRC EBoard has created a new website to represent the club. This changes the NRC layout to redirect to NRC's new website with a 301 redirect for SEO. It will only affect all NRC pages, leaving the team and home pages intact.